### PR TITLE
Governance seed files — bootstrap v1.0

### DIFF
--- a/CC_CHAT_LOG.md
+++ b/CC_CHAT_LOG.md
@@ -1,0 +1,15 @@
+# CC_CHAT_LOG.md — i-flexthailand.com
+> Version 1.0 — 2026-06-25
+> Changes: Initial creation — first entry
+> Previous: NONE
+
+---
+
+## 2026-06-25 — Governance bootstrap scan
+**Did:** Seed CLAUDE.md, CC_CHAT_LOG.md, PROJECT_STATE.md created. No source files touched.
+**Updated:** NONE (new files only)
+**New files:** CLAUDE.md, CC_CHAT_LOG.md, PROJECT_STATE.md
+**Pending Chat verify:** NONE
+**Flags:** LARGE FILE — js/iflex-config.js (1193L), js/iflex-core.js (789L). RETROFIT CANDIDATE — schema.org missing, hreflang missing, TH pages missing OG block. Site uses STANDALONE injector — not central.
+
+---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md — i-flexthailand.com
+> Version 1.0 — 2026-06-25
+> Changes: Initial creation — governance seed
+> Previous: NONE
+
+Project: I-Flex Thailand — Professional Pilates equipment, bilingual EN/TH (BUS01)
+Domain: i-flexthailand.com
+BUS ID: BUS01
+
+Governance: ALL rules at janishammer-central/RULES.md + .claude/rules/
+Read janishammer-central CLAUDE.md before reading anything in this repo.
+
+Injector:
+  injector-config.js — STANDALONE LOCAL at /js/iflex-config.js (1193L ⚠️)
+  injector-core.js   — STANDALONE LOCAL at /js/iflex-core.js (789L)
+  NOTE: NOT using central injector from assets.janishammer.com
+
+Local key files:
+  js/iflex-config.js       — standalone brand config + all CSS (1193 lines — over limit)
+  js/iflex-core.js         — standalone nav/footer/GA/language switcher
+  scripts/generate_blog.py — Airtable → bilingual blog HTML
+  scripts/generate_products.py — Airtable → bilingual product HTML
+  index.html               — EN homepage (590L)
+
+Critical constraint: This site uses a standalone injector fork — changes to
+janishammer-central/js/ do NOT affect this site. Schema.org, hreflang, and
+og:type on TH pages are missing — see RETROFIT_QUEUE items #1–#7.
+
+Tech: Vanilla HTML/CSS/JS · Airtable · Python build · GitHub Actions · Cloudflare Pages

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,36 @@
+# PROJECT_STATE.md — i-flexthailand.com
+> Version 1.0 — 2026-06-25
+> Changes: Initial creation — bootstrap scan
+> Previous: NONE
+
+## Status: LIVE
+## Domain: https://i-flexthailand.com
+## Last observed state: Full bilingual site live. 5 GitHub Action workflows active. Blog (5 EN/5 TH posts) and products (9 EN/9 TH) generated from Airtable. Gallery, news, testimonials also generated.
+## Tech stack: Vanilla HTML/CSS/JS · Airtable (appMBjlfYyVd8I7ML) · Python build · GitHub Actions · Cloudflare Pages
+## Injector version: STANDALONE — not using central injector. Local js/iflex-config.js (v2.0) + js/iflex-core.js
+
+## Folder structure:
+  Compliant: NO
+  Issues: All HTML files at repo root (index.html, about-us.html, contact-us.html, case-study.html, product-listing.html, blog-listing.html). No /public/ folder. th/ subfolder exists for TH mirrors. blog/ and product/ subdirectories used for generated posts.
+
+## SEO status (from scan):
+  OG tags:   present on EN index.html. Partial or missing on TH pages and inner pages.
+  Canonical: present on EN index.html and th/index.html. Status unknown on inner pages.
+  Schema:    missing — no schema.org markup found on any page
+  Hreflang:  missing — EN/TH pages not linked via hreflang
+
+## Security status (from scan):
+  No issues found. All Airtable credentials in GitHub Secrets. Python scripts use os.environ.get(). No keys in any client-side file.
+
+## Open issues observed:
+  - js/iflex-config.js: 1193 lines — over 800 limit
+  - js/iflex-core.js: 789 lines — at limit
+  - schema.org missing on all pages (homepage, blog, products)
+  - hreflang missing on all bilingual pages
+  - TH pages missing complete OG block (og:type, og:title, og:description, og:image, og:url)
+  - Twitter cards missing on TH pages
+  - Site uses standalone injector — diverged from central injector
+
+## Session log (newest first):
+### 2026-06-25 — Bootstrap scan
+Seed CLAUDE.md, CC_CHAT_LOG.md, PROJECT_STATE.md created. No source files touched.


### PR DESCRIPTION
## Summary
- Adds 3 governance seed files: `CLAUDE.md`, `CC_CHAT_LOG.md`, `PROJECT_STATE.md`
- Zero source files touched — documentation only
- Part of janishammer-central governance bootstrap (see central repo PR)

## Key findings recorded (do not fix here — fix in dedicated sessions)
- `js/iflex-config.js`: 1193 lines ⚠️ over 800-line limit
- Site uses standalone local injector — NOT the central injector from `assets.janishammer.com`
- `schema.org` missing on all pages (homepage, blog, products)
- `hreflang` missing on all bilingual page pairs
- TH pages missing complete OG block
- All HTML at repo root — no `/public/` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01TktcuYEWLxsGt2mijLbKjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TktcuYEWLxsGt2mijLbKjg)_