### PR TITLE
Fix broken "Request Quote" links on English product pages

### DIFF
--- a/product/aluminum-reformer-foldable.html
+++ b/product/aluminum-reformer-foldable.html
@@ -157,7 +157,7 @@
                 <h3>Features</h3>
                 <ul><li>No features listed</li></ul>
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/ba-reformer-with-full-tower.html
+++ b/product/ba-reformer-with-full-tower.html
@@ -172,7 +172,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/maple-reformer-with-full-tower.html
+++ b/product/maple-reformer-with-full-tower.html
@@ -173,7 +173,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/maple-reformer.html
+++ b/product/maple-reformer.html
@@ -174,7 +174,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/oak-cadillac.html
+++ b/product/oak-cadillac.html
@@ -171,7 +171,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/oak-ladder-barrel.html
+++ b/product/oak-ladder-barrel.html
@@ -169,7 +169,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/oak-reformer-with-full-tower.html
+++ b/product/oak-reformer-with-full-tower.html
@@ -173,7 +173,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/oak-reformer-with-half-tower.html
+++ b/product/oak-reformer-with-half-tower.html
@@ -172,7 +172,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/oak-reformer.html
+++ b/product/oak-reformer.html
@@ -173,7 +173,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/product/oak-wunda-chair.html
+++ b/product/oak-wunda-chair.html
@@ -169,7 +169,7 @@
 </ul>
 
             </div>
-            <a href="/en/contact-us.html" class="btn">Request Quote</a>
+            <a href="/contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="/product-listing.html" class="btn-back">← Back to Products</a>

--- a/scripts/generate_products.py
+++ b/scripts/generate_products.py
@@ -253,7 +253,7 @@ PRODUCT_TEMPLATE = '''<!DOCTYPE html>
                 <h3>Features</h3>
                 {features_html}
             </div>
-            <a href="/{lang}/contact-us.html" class="btn">Request Quote</a>
+            <a href="{back_link}contact-us.html" class="btn">Request Quote</a>
             
             <div class="product-navigation">
                 <a href="{back_link}product-listing.html" class="btn-back">← Back to Products</a>


### PR DESCRIPTION
## Summary
- All 10 English product pages linked "Request Quote" to `/en/contact-us.html`, which doesn't exist — English pages live at the site root, not under `/en/`. Thai pages already linked correctly to `/th/contact-us.html`.
- Fixed the 10 static generated files: `href="/en/contact-us.html"` → `href="/contact-us.html"`.
- Fixed `scripts/generate_products.py` (~line 256) to reuse the existing `back_link` variable instead of hardcoding `/{lang}/`, so the next auto-generated run won't regress this.

## Files changed
- `scripts/generate_products.py`
- `product/aluminum-reformer-foldable.html`
- `product/ba-reformer-with-full-tower.html`
- `product/maple-reformer-with-full-tower.html`
- `product/maple-reformer.html`
- `product/oak-cadillac.html`
- `product/oak-ladder-barrel.html`
- `product/oak-reformer-with-full-tower.html`
- `product/oak-reformer-with-half-tower.html`
- `product/oak-reformer.html`
- `product/oak-wunda-chair.html`

## Test plan
- [x] Verified no remaining `/en/contact-us.html` references anywhere in the repo (`grep` returns no matches)
- [x] Confirmed `back_link` resolves to `/` for `lang='en'` and `/th/` for `lang='th'` at the two `generate_product_page()` call sites


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cpdkm1BNsHEgjPHLyUHBms)_